### PR TITLE
chore: modernize Terraform and provider versions

### DIFF
--- a/infrastructure/policy/modules/role_assignments_for_policy/versions.tf
+++ b/infrastructure/policy/modules/role_assignments_for_policy/versions.tf
@@ -6,9 +6,9 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.19.0"
+      version = "~> 3.116"
     }
   }
 
-  required_version = ">= 1.3.1"
+  required_version = ">= 1.9"
 }

--- a/infrastructure/policy/versions.tf
+++ b/infrastructure/policy/versions.tf
@@ -18,11 +18,11 @@ terraform {
     key = "anoa-policy"
   }
 
-  required_version = ">= 1.3"
+  required_version = ">= 1.9"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.36"
+      version = "~> 3.116"
     }
     azuread = {
       source  = "hashicorp/azuread"


### PR DESCRIPTION
## Summary
Modernize version constraints across root and submodule.

### Changes
- Root: Terraform `>= 1.3` → `>= 1.9`, azurerm `~> 3.36` → `~> 3.116`
- role_assignments module: Terraform `>= 1.3.1` → `>= 1.9`, azurerm `>= 3.19.0` → `~> 3.116`
- Other providers (azuread, random, time, tls, null) unchanged

Closes #1